### PR TITLE
Fix broken ping

### DIFF
--- a/src/clamd.php
+++ b/src/clamd.php
@@ -34,8 +34,7 @@ abstract class ClamdBase {
     
     /* `ping` command is used to see whether Clamd is alive or not */
     public function ping() {
-        $return = $this->sendCommand('PING');
-        return strcmp($return, 'PONG') ? true : false;
+        return (trim($this->sendCommand('PING')) === 'PONG');
     }
 
     /* `version` is used to receive the version of Clamd */


### PR DESCRIPTION
returning "strcmp" directly is wrong (because its return value is != 0 if the strings differ¹), so trim the response of clamd first and use a strict string comparison

[1] http://php.net/manual/en/function.strcmp.php#refsect1-function.strcmp-returnvalues
